### PR TITLE
Add iter and next to sandbox builtins

### DIFF
--- a/nbs/00_core.ipynb
+++ b/nbs/00_core.ipynb
@@ -460,6 +460,7 @@
     "#| export\n",
     "all_builtins = safe_builtins | utility_builtins | limited_builtins | async_builtins | dict(\n",
     "    dict=dict, list=list, set=set, tuple=tuple, frozenset=frozenset,\n",
+    "    iter=iter, next=next,\n",
     "    __import__=__import__\n",
     ")"
    ]

--- a/safepyrun/core.py
+++ b/safepyrun/core.py
@@ -118,6 +118,7 @@ def _safe_open(ok_dests):
 # %% ../nbs/00_core.ipynb #12f3bde3
 all_builtins = safe_builtins | utility_builtins | limited_builtins | async_builtins | dict(
     dict=dict, list=list, set=set, tuple=tuple, frozenset=frozenset,
+    iter=iter, next=next,
     __import__=__import__
 )
 


### PR DESCRIPTION
Adds `iter` and `next` to the allowed builtins in the sandbox, enabling iteration protocols for 
user code.