### PR TITLE
fix: RunPython lazy globals lookup to avoid capturing wrong globals

### DIFF
--- a/nbs/00_core.ipynb
+++ b/nbs/00_core.ipynb
@@ -747,8 +747,7 @@
     "#| export\n",
     "class RunPython:\n",
     "    def __init__(self, g=None, sentinel=None, ok_dests=None):\n",
-    "        if not g: g = _find_frame_dict(sentinel)\n",
-    "        self.g,self.ok_dests = g,ok_dests\n",
+    "        self.g, self.ok_dests, self.sentinel = g, ok_dests, sentinel\n",
     "\n",
     "    @property\n",
     "    def __doc__(self):\n",
@@ -768,7 +767,8 @@
     "            `[x**2 for x in range(5)]` (last expression returned); `sorted(my_dict.items())` (builtin + non-callable attr)\"\"\"\n",
     "\n",
     "    async def __call__(self, code:str, concise:bool=True):\n",
-    "        return await _run_python(code, g=self.g, ok_dests=self.ok_dests, concise=concise)"
+    "        if not self.g: self.g = _find_frame_dict(self.sentinel)\n",
+    "        return await _run_python(code, g=self.g or globals(), ok_dests=self.ok_dests, concise=concise)"
    ]
   },
   {

--- a/safepyrun/core.py
+++ b/safepyrun/core.py
@@ -236,8 +236,7 @@ async def _run_python(code:str, g=None, ok_dests=None, concise=True):
 # %% ../nbs/00_core.ipynb #4b971b78
 class RunPython:
     def __init__(self, g=None, sentinel=None, ok_dests=None):
-        if not g: g = _find_frame_dict(sentinel)
-        self.g,self.ok_dests = g,ok_dests
+        self.g, self.ok_dests, self.sentinel = g, ok_dests, sentinel
 
     @property
     def __doc__(self):
@@ -257,7 +256,8 @@ class RunPython:
             `[x**2 for x in range(5)]` (last expression returned); `sorted(my_dict.items())` (builtin + non-callable attr)"""
 
     async def __call__(self, code:str, concise:bool=True):
-        return await _run_python(code, g=self.g, ok_dests=self.ok_dests, concise=concise)
+        if not self.g: self.g = _find_frame_dict(self.sentinel)
+        return await _run_python(code, g=self.g or globals(), ok_dests=self.ok_dests, concise=concise)
 
 # %% ../nbs/00_core.ipynb #2303931f
 def safe_type(o:object):


### PR DESCRIPTION
`pyrun` may capture wrong globals when `dialoghelpers` are imported early.
This PR adds lazy loading. Similar code size, but adds a bit of complexity:  `pyrun.g` is `None` before the first call to `pyrun('')`.

While writing this I found the root cause: an IPython startup script that I had, was loading dialoghelpers early.
I decided to keep this PR anyway, as if this happens it is hard to track and makes the solveit AI quite confused.