### PR TITLE
Add expanduser to allowed Path methods

### DIFF
--- a/nbs/00_core.ipynb
+++ b/nbs/00_core.ipynb
@@ -985,7 +985,7 @@
     "        'zfill', 'center', 'ljust', 'rjust', 'maketrans', 'translate', 'casefold', 'partition', 'rpartition'],\n",
     "    bytes: ['decode', 'fromhex', 'hex'],\n",
     "    int: ['to_bytes', 'from_bytes', 'bit_length'],\n",
-    "    Path: ['read_text', 'glob', 'iterdir', 'exists', 'read_bytes', 'is_file', 'is_dir', 'stat', 'resolve',\n",
+    "    Path: ['expanduser', 'read_text', 'glob', 'iterdir', 'exists', 'read_bytes', 'is_file', 'is_dir', 'stat', 'resolve',\n",
     "        'with_suffix', 'with_name', 'relative_to', 'match', 'joinpath'],\n",
     "    asyncio: ['gather'], copy: ['deepcopy'], httpx: ['get', 'options'],\n",
     "    itertools: ['chain', 'islice', 'groupby', 'product', 'permutations', 'combinations', 'accumulate', 'starmap', 'zip_longest',\n",

--- a/safepyrun/core.py
+++ b/safepyrun/core.py
@@ -295,7 +295,7 @@ allow({
         'zfill', 'center', 'ljust', 'rjust', 'maketrans', 'translate', 'casefold', 'partition', 'rpartition'],
     bytes: ['decode', 'fromhex', 'hex'],
     int: ['to_bytes', 'from_bytes', 'bit_length'],
-    Path: ['read_text', 'glob', 'iterdir', 'exists', 'read_bytes', 'is_file', 'is_dir', 'stat', 'resolve',
+    Path: ['expanduser', 'read_text', 'glob', 'iterdir', 'exists', 'read_bytes', 'is_file', 'is_dir', 'stat', 'resolve',
         'with_suffix', 'with_name', 'relative_to', 'match', 'joinpath'],
     asyncio: ['gather'], copy: ['deepcopy'], httpx: ['get', 'options'],
     itertools: ['chain', 'islice', 'groupby', 'product', 'permutations', 'combinations', 'accumulate', 'starmap', 'zip_longest',


### PR DESCRIPTION
Adds `Path.expanduser()` to the allowlist, enabling safe expansion of `~` in paths.