### PR TITLE
fix pyrun namespace to use kernel's user_ns

### DIFF
--- a/nbs/00_core.ipynb
+++ b/nbs/00_core.ipynb
@@ -1967,7 +1967,7 @@
     "#| export\n",
     "def load_ipython_extension(ip):\n",
     "    ns = ip.user_ns\n",
-    "    ns['pyrun'] = pyrun = RunPython()\n",
+    "    ns['pyrun'] = pyrun = RunPython(g=ns)\n",
     "    create_pyrun_magic(ip, pyrun)"
    ]
   },

--- a/safepyrun/core.py
+++ b/safepyrun/core.py
@@ -410,5 +410,5 @@ def allow_matplotlib():
 # %% ../nbs/00_core.ipynb #8d1cb417
 def load_ipython_extension(ip):
     ns = ip.user_ns
-    ns['pyrun'] = pyrun = RunPython()
+    ns['pyrun'] = pyrun = RunPython(g=ns)
     create_pyrun_magic(ip, pyrun)


### PR DESCRIPTION
`load_ipython_extension` was creating `RunPython()` without passing the kernel namespace, so `_find_frame_dict(None)` captured `safepyrun.core`'s module globals instead of `ip.user_ns`. This meant user-defined functions (and CRAFT-loaded functions) were invisible to pyrun. Fixed by passing `g=ns` to `RunPython()`.