### PR TITLE
Show source code for line causing an exception.

### DIFF
--- a/nbs/00_core.ipynb
+++ b/nbs/00_core.ipynb
@@ -674,6 +674,46 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "12b831de",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#| export\n",
+    "\n",
+    "def srcfn(src):\n",
+    "    \"Stores src in linecache under <pyrun_{i%10}>, returns the name.\" \n",
+    "    linecache.cache[fn] = (len(src), None,  src.splitlines(keepends=True), fn:=f'<pyrun_{srcfn.i}>')\n",
+    "    srcfn.i = (srcfn.i + 1)%10\n",
+    "    return fn\n",
+    "srcfn.i=0"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d159c2d1",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "('<pyrun_0>', '<pyrun_1>')"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {
+      "__type": "tuple"
+     },
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "srcfn(''),srcfn('')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "55cc6157",
    "metadata": {},
    "outputs": [],
@@ -691,7 +731,7 @@
     "    rg = dict(__builtins__=builtins, _getattr_=_make_safe_getattr(ok_dests),\n",
     "        _inplacevar_ = _inplacevar_, type = _safe_type,\n",
     "        _getitem_=lambda o,k: o[k], _getiter_=iter, _apply_ = lambda f, *a, **kw: f(*a, **kw),\n",
-    "        _write_=_default_write_, __metaclass__=type, __name__='<tool>',\n",
+    "        _write_=_default_write_, __metaclass__=type, __name__='<pyrun>',\n",
     "        _print_=_DirectPrint, _print=_DirectPrint(),\n",
     "        _unpack_sequence_=unpack, _iter_unpack_sequence_=unpack,\n",
     "        enumerate=enumerate, sorted=sorted, reversed=reversed, max=max, min=min, **tools)\n",
@@ -699,7 +739,7 @@
     "    loc = {}\n",
     "    async def run(src, is_exec=True):\n",
     "        try:\n",
-    "            comp = compile_restricted(src, '<tool>', 'exec' if is_exec else 'eval', policy=SafeTransformer)\n",
+    "            comp = compile_restricted(src, srcfn(src), 'exec' if is_exec else 'eval', policy=SafeTransformer)\n",
     "            r = eval(comp, rg, loc)\n",
     "            return (await r) if inspect.isawaitable(r) else r\n",
     "        except SyntaxError as e:\n",
@@ -780,7 +820,7 @@
     "        try: return await _run_python(code, g=self.g, ok_dests=self.ok_dests)\n",
     "        except Exception as e:\n",
     "            tb = e.__traceback__\n",
-    "            while tb.tb_next: tb = tb.tb_next\n",
+    "            while tb.tb_next and not tb.tb_frame.f_code.co_filename.startswith('<pyrun'): tb = tb.tb_next\n",
     "            raise e.with_traceback(tb) from None"
    ]
   },
@@ -823,6 +863,35 @@
    ],
    "source": [
     "await pyrun('[]')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d69bc9c8",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Traceback (most recent call last):\n",
+      "  File \"/var/folders/q_/6ypbtk8976j5j9zhzn30df440000gn/T/ipykernel_34690/2137266802.py\", line 1, in <module>\n",
+      "    try: await pyrun('import os; os.system(\"ls\");')\n",
+      "         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+      "  File \"/var/folders/q_/6ypbtk8976j5j9zhzn30df440000gn/T/ipykernel_34690/3906047838.py\", line 38, in __call__\n",
+      "    raise e.with_traceback(tb) from None\n",
+      "  File \"<pyrun_6>\", line 1, in <module>\n",
+      "    os.system('ls')\n",
+      "  File \"/var/folders/q_/6ypbtk8976j5j9zhzn30df440000gn/T/ipykernel_34690/343110701.py\", line 14, in __call__\n",
+      "    raise PermissionError(f\"Calling {type(object.__getattribute__(self, '_obj')).__name__} not allowed in sandbox\")\n",
+      "PermissionError: Calling builtin_function_or_method not allowed in sandbox\n"
+     ]
+    }
+   ],
+   "source": [
+    "try: await pyrun('import os; os.system(\"ls\");')\n",
+    "except Exception as e: traceback.print_exception(e)"
    ]
   },
   {
@@ -2181,6 +2250,9 @@
   }
  ],
  "metadata": {
+  "language_info": {
+   "name": "python"
+  },
   "solveit_dialog_mode": "learning",
   "solveit_ver": 2
  },

--- a/safepyrun/core.py
+++ b/safepyrun/core.py
@@ -2,7 +2,7 @@
 
 # %% auto #0
 __all__ = ['all_builtins', 'ALLOWED_DUNDERS', 'default_ok_dests', 'find_var', 'allow_write_types', 'sdir', 'SafeTransformer',
-           'should_export', 'RunPython', 'create_pyrun_magic', 'allow_matplotlib', 'load_ipython_extension']
+           'should_export', 'srcfn', 'RunPython', 'create_pyrun_magic', 'allow_matplotlib', 'load_ipython_extension']
 
 # %% ../nbs/00_core.ipynb #468aa264
 from fastcore.utils import *
@@ -235,6 +235,14 @@ def should_export(k, v, g):
     if k.endswith('_'): return True
     return not (k in g and (callable(v) or isinstance(v, types.ModuleType)))
 
+# %% ../nbs/00_core.ipynb #12b831de
+def srcfn(src):
+    "Stores src in linecache under <pyrun_{i%10}>, returns the name." 
+    linecache.cache[fn] = (len(src), None,  src.splitlines(keepends=True), fn:=f'<pyrun_{srcfn.i}>')
+    srcfn.i = (srcfn.i + 1)%10
+    return fn
+srcfn.i=0
+
 # %% ../nbs/00_core.ipynb #55cc6157
 async def _run_python(code:str, g=None, ok_dests=None):
     _rp_globals.set(g)
@@ -248,7 +256,7 @@ async def _run_python(code:str, g=None, ok_dests=None):
     rg = dict(__builtins__=builtins, _getattr_=_make_safe_getattr(ok_dests),
         _inplacevar_ = _inplacevar_, type = _safe_type,
         _getitem_=lambda o,k: o[k], _getiter_=iter, _apply_ = lambda f, *a, **kw: f(*a, **kw),
-        _write_=_default_write_, __metaclass__=type, __name__='<tool>',
+        _write_=_default_write_, __metaclass__=type, __name__='<pyrun>',
         _print_=_DirectPrint, _print=_DirectPrint(),
         _unpack_sequence_=unpack, _iter_unpack_sequence_=unpack,
         enumerate=enumerate, sorted=sorted, reversed=reversed, max=max, min=min, **tools)
@@ -256,7 +264,7 @@ async def _run_python(code:str, g=None, ok_dests=None):
     loc = {}
     async def run(src, is_exec=True):
         try:
-            comp = compile_restricted(src, '<tool>', 'exec' if is_exec else 'eval', policy=SafeTransformer)
+            comp = compile_restricted(src, srcfn(src), 'exec' if is_exec else 'eval', policy=SafeTransformer)
             r = eval(comp, rg, loc)
             return (await r) if inspect.isawaitable(r) else r
         except SyntaxError as e:
@@ -312,7 +320,7 @@ class RunPython:
         try: return await _run_python(code, g=self.g, ok_dests=self.ok_dests)
         except Exception as e:
             tb = e.__traceback__
-            while tb.tb_next: tb = tb.tb_next
+            while tb.tb_next and not tb.tb_frame.f_code.co_filename.startswith('<pyrun'): tb = tb.tb_next
             raise e.with_traceback(tb) from None
 
 # %% ../nbs/00_core.ipynb #9105f690


### PR DESCRIPTION
Previously exception just showed the line  number like <tool>:3, without source code.

Now they show the source code too.

There are mutliple files to allow for concurrent execution of pyrun.
