### PR TITLE
Add CLI documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,10 +304,12 @@ await asyncio.gather(fetch(1), fetch(2), fetch(3))
 
 ## Writable path permissions
 
-By default, `RunPython` blocks all filesystem writes. To enable
-controlled writing, pass `ok_dests` — a list of directory prefixes where
-writes are permitted. Writing to an allowed destination works normally,
-but writing anywhere else raises `PermissionError`:
+By default,
+[`RunPython`](https://AnswerDotAI.github.io/safepyrun/core.html#runpython)
+blocks all filesystem writes. To enable controlled writing, pass
+`ok_dests` — a list of directory prefixes where writes are permitted.
+Writing to an allowed destination works normally, but writing anywhere
+else raises `PermissionError`:
 
 ``` python
 pyrun2 = RunPython(ok_dests=['/tmp'])
@@ -371,8 +373,10 @@ except PermissionError as e: print(f'Blocked: {e}')
 
     Blocked: Dest '/root/bad.txt' not allowed; permitted: ['/tmp']
 
-Without `ok_dests`, the default `RunPython` instance blocks all write
-operations entirely — `Path.write_text` isn’t even callable:
+Without `ok_dests`, the default
+[`RunPython`](https://AnswerDotAI.github.io/safepyrun/core.html#runpython)
+instance blocks all write operations entirely — `Path.write_text` isn’t
+even callable:
 
 ``` python
 try: await pyrun("Path('/tmp/test.txt').write_text('nope')")
@@ -502,3 +506,19 @@ allow_write({'DataFrame.to_csv': PosWritePolicy(0, 'path_or_buf')})
 
 If the config file has errors, a warning is emitted and the defaults
 remain intact.
+
+## CLI
+
+safepyrun ships with a command-line tool that runs a Python script file
+in the sandbox. You can pass a file path, or pipe code in via stdin:
+
+``` sh
+# Run a script file
+$ safepyrun myscript.py
+
+# Pipe code via stdin
+$ echo "1+1" | safepyrun
+```
+
+The result of the last expression is printed to stdout, matching the
+behaviour of `pyrun` in Python. Errors are reported to stderr.

--- a/nbs/index.ipynb
+++ b/nbs/index.ipynb
@@ -135,9 +135,7 @@
       ]
      },
      "execution_count": null,
-     "metadata": {
-      "__type": "int"
-     },
+     "metadata": {},
      "output_type": "execute_result"
     }
    ],
@@ -173,9 +171,7 @@
       ]
      },
      "execution_count": null,
-     "metadata": {
-      "__type": "int"
-     },
+     "metadata": {},
      "output_type": "execute_result"
     }
    ],
@@ -211,9 +207,7 @@
       ]
      },
      "execution_count": null,
-     "metadata": {
-      "__type": "str"
-     },
+     "metadata": {},
      "output_type": "execute_result"
     }
    ],
@@ -246,9 +240,7 @@
       ]
      },
      "execution_count": null,
-     "metadata": {
-      "__type": "list"
-     },
+     "metadata": {},
      "output_type": "execute_result"
     }
    ],
@@ -305,9 +297,7 @@
       ]
      },
      "execution_count": null,
-     "metadata": {
-      "__type": "str"
-     },
+     "metadata": {},
      "output_type": "execute_result"
     }
    ],
@@ -339,9 +329,7 @@
       ]
      },
      "execution_count": null,
-     "metadata": {
-      "__type": "int"
-     },
+     "metadata": {},
      "output_type": "execute_result"
     }
    ],
@@ -382,9 +370,7 @@
       ]
      },
      "execution_count": null,
-     "metadata": {
-      "__type": "int64"
-     },
+     "metadata": {},
      "output_type": "execute_result"
     }
    ],
@@ -416,9 +402,7 @@
       ]
      },
      "execution_count": null,
-     "metadata": {
-      "__type": "float64"
-     },
+     "metadata": {},
      "output_type": "execute_result"
     }
    ],
@@ -478,9 +462,7 @@
       ]
      },
      "execution_count": null,
-     "metadata": {
-      "__type": "list"
-     },
+     "metadata": {},
      "output_type": "execute_result"
     }
    ],
@@ -509,9 +491,7 @@
       ]
      },
      "execution_count": null,
-     "metadata": {
-      "__type": "dict"
-     },
+     "metadata": {},
      "output_type": "execute_result"
     }
    ],
@@ -557,9 +537,7 @@
       ]
      },
      "execution_count": null,
-     "metadata": {
-      "__type": "list"
-     },
+     "metadata": {},
      "output_type": "execute_result"
     }
    ],
@@ -620,9 +598,7 @@
       ]
      },
      "execution_count": null,
-     "metadata": {
-      "__type": "int"
-     },
+     "metadata": {},
      "output_type": "execute_result"
     }
    ],
@@ -670,9 +646,7 @@
       ]
      },
      "execution_count": null,
-     "metadata": {
-      "__type": "int"
-     },
+     "metadata": {},
      "output_type": "execute_result"
     }
    ],
@@ -720,9 +694,7 @@
       ]
      },
      "execution_count": null,
-     "metadata": {
-      "__type": "str"
-     },
+     "metadata": {},
      "output_type": "execute_result"
     }
    ],
@@ -751,9 +723,7 @@
       ]
      },
      "execution_count": null,
-     "metadata": {
-      "__type": "str"
-     },
+     "metadata": {},
      "output_type": "execute_result"
     }
    ],
@@ -820,9 +790,7 @@
       ]
      },
      "execution_count": null,
-     "metadata": {
-      "__type": "int"
-     },
+     "metadata": {},
      "output_type": "execute_result"
     }
    ],
@@ -1029,9 +997,40 @@
     "\n",
     "If the config file has errors, a warning is emitted and the defaults remain intact."
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8fa2f3a0",
+   "metadata": {},
+   "source": [
+    "## CLI"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "699b5ab4",
+   "metadata": {},
+   "source": [
+    "safepyrun ships with a command-line tool that runs a Python script file\n",
+    "in the sandbox. You can pass a file path, or pipe code in via stdin:\n",
+    "\n",
+    "``` sh\n",
+    "# Run a script file\n",
+    "$ safepyrun myscript.py\n",
+    "\n",
+    "# Pipe code via stdin\n",
+    "$ echo \"1+1\" | safepyrun\n",
+    "```\n",
+    "\n",
+    "The result of the last expression is printed to stdout, matching the\n",
+    "behaviour of `pyrun` in Python. Errors are reported to stderr."
+   ]
   }
  ],
- "metadata": {},
+ "metadata": {
+  "solveit_dialog_mode": "learning",
+  "solveit_ver": 2
+ },
  "nbformat": 4,
  "nbformat_minor": 5
 }


### PR DESCRIPTION
Adds documentation for the safepyrun command-line tool, including usage examples for running script files and piping code via stdin. Also adds hyperlinks to RunPython in the README.