### PR TITLE
fixed outdated readme & wrong default permissons

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,8 @@ warnings.warn('a warning')
 ''')
 ```
 
-    <tool>:2: UserWarning: a warning
+    <pyrun_3>:2: UserWarning: a warning
+      warnings.warn('a warning')
 
     'ok'
 
@@ -222,7 +223,7 @@ allow(np.array, np.ndarray.sum)
 await pyrun('np.array([1,2,3]).sum()')
 ```
 
-    6
+    np.int64(6)
 
 Note that the string must use the actual class or module name as it
 appears in Python, not the alias. In the example above, even though the
@@ -238,7 +239,7 @@ allow({np.ndarray: ['mean', 'reshape', 'tolist']})
 await pyrun('np.array([1,2,3,4]).reshape(2,2).mean()')
 ```
 
-    2.5
+    np.float64(2.5)
 
 The dict form does two things: it registers the class/module name itself
 (so it can be called as a constructor or accessed as a namespace), and
@@ -305,11 +306,10 @@ await asyncio.gather(fetch(1), fetch(2), fetch(3))
 ## Writable path permissions
 
 By default,
-[`RunPython`](https://AnswerDotAI.github.io/safepyrun/core.html#runpython)
-blocks all filesystem writes. To enable controlled writing, pass
-`ok_dests` — a list of directory prefixes where writes are permitted.
-Writing to an allowed destination works normally, but writing anywhere
-else raises `PermissionError`:
+[`RunPython()`](https://AnswerDotAI.github.io/safepyrun/core.html#runpython)
+allows writes to the current working directory (`.`) and `/tmp`, and
+blocks writes elsewhere. You can pass `ok_dests` to restrict writes to a
+different set of directory prefixes:
 
 ``` python
 pyrun2 = RunPython(ok_dests=['/tmp'])
@@ -330,7 +330,7 @@ try: await pyrun2("Path('/etc/evil.txt').write_text('bad')")
 except PermissionError as e: print(f'Blocked: {e}')
 ```
 
-    Blocked: Dest '/etc/evil.txt' not allowed; permitted: ['/tmp']
+    Blocked: Dest '/etc/evil.txt' not allowed; permitted: ('/tmp',)
 
 The same permission checking applies to `open()` in write mode, not just
 `Path` methods:
@@ -346,7 +346,7 @@ try: await pyrun2("open('/root/bad.txt', 'w')")
 except PermissionError as e: print(f'Blocked: {e}')
 ```
 
-    Blocked: Dest '/root/bad.txt' not allowed; permitted: ['/tmp']
+    Blocked: Dest '/root/bad.txt' not allowed; permitted: ('/tmp',)
 
 Read access is unaffected — only writes are gated:
 
@@ -371,17 +371,32 @@ try: await pyrun2("import shutil; shutil.copy('/tmp/test_write.txt', '/root/bad.
 except PermissionError as e: print(f'Blocked: {e}')
 ```
 
-    Blocked: Dest '/root/bad.txt' not allowed; permitted: ['/tmp']
+    Blocked: Dest '/root/bad.txt' not allowed; permitted: ('/tmp',)
 
-Without `ok_dests`, the default
-[`RunPython`](https://AnswerDotAI.github.io/safepyrun/core.html#runpython)
-instance blocks all write operations entirely — `Path.write_text` isn’t
-even callable:
+By default,
+[`RunPython()`](https://AnswerDotAI.github.io/safepyrun/core.html#runpython)
+uses `default_ok_dests`, which allows writes in `.` and `/tmp` but
+blocks writes elsewhere.
 
 ``` python
-try: await pyrun("Path('/tmp/test.txt').write_text('nope')")
-except AttributeError as e: print(f'No ok_dests: {e}')
+await pyrun("Path('test_default_ok.txt').write_text('ok')")
+await pyrun("Path('/tmp/test_default_tmp.txt').write_text('tmp')")
+
+try: await pyrun("Path('/etc/nope.txt').write_text('bad')")
+except PermissionError as e: print(f'Default blocked: {e}')
 ```
+
+    Default blocked: Dest '/etc/nope.txt' not allowed; permitted: ('.', '/tmp')
+
+If you want to disable write protection entirely, pass `ok_dests=None`:
+
+``` python
+pyrun_unrestricted = RunPython(ok_dests=None)
+unrestricted_path = Path.home()/'safepyrun-unrestricted.txt'
+await pyrun_unrestricted(f"Path({str(unrestricted_path)!r}).write_text('ok')")
+```
+
+    2
 
 You can use `'.'` to allow writes relative to the current working
 directory. Path traversal attempts (`../`, `subdir/../../`) are detected
@@ -424,12 +439,12 @@ except PermissionError: print("Blocked ../ as expected")
 When `ok_dests` is set, safepyrun uses write policies to determine how
 to validate each callable’s destination arguments. Three built-in policy
 classes cover common patterns: checking a positional or keyword argument
-(`PosWritePolicy`), checking the `Path` object itself
+(`PosAllowPolicy`), checking the `Path` object itself
 (`PathWritePolicy`), and checking `open()` calls only when the mode is
-writable (`OpenWritePolicy`). You can also subclass `WritePolicy` to
+writable (`OpenWritePolicy`). You can also subclass `AllowPolicy` to
 create custom checks.
 
-The simplest, `PosWritePolicy`, checks a specific positional or keyword
+The simplest, `PosAllowPolicy`, checks a specific positional or keyword
 argument against the allowed destinations. Here, position 1 (or keyword
 `dst`) is validated — writing to `/tmp` is allowed, but `/root` is
 blocked:
@@ -443,11 +458,10 @@ except PermissionError: print("PosAllowPolicy correctly blocked /root/bad")
 
     PosAllowPolicy correctly blocked /root/bad
 
-You can create custom write policies by subclassing `WritePolicy` and
-implementing the `check` method. For example, here we show a policy that
-only allows writes to files with specific extensions — useful if you
-want the LLM to create `.csv` or `.json` files but not arbitrary
-scripts.
+You can create custom write policies by subclassing `AllowPolicy` and
+implementing `__call__`. For example, here we show a policy that only
+allows writes to files with specific extensions — useful if you want the
+LLM to create `.csv` or `.json` files but not arbitrary scripts.
 
 The `__call__` signature receives `(obj, args, kwargs, ok_dests)` where
 `obj` is the object the method is called on (e.g. a `Path` instance),
@@ -487,9 +501,10 @@ allow({Path: [('write_text', ExtWritePolicy(['.csv', '.json', '.txt']))]})
 defaults are registered. This lets you permanently extend the sandbox
 allowlists without modifying the package. The config file is executed
 with all `safepyrun.core` globals already available, so no imports are
-needed. This includes `allow`, `allow_write`, `WritePolicy`,
-`PathWritePolicy`, `PosWritePolicy`, `OpenWritePolicy`, and all standard
-library modules already imported by the module.
+needed. This includes `allow`,
+[`allow_write_types`](https://AnswerDotAI.github.io/safepyrun/core.html#allow_write_types),
+`AllowPolicy`, `PathWritePolicy`, `PosAllowPolicy`, `OpenWritePolicy`,
+and all standard library modules already imported by the module.
 
 Example `~/.config/safepyrun/config.py` (Linux) or
 `~/Library/Application Support/safepyrun/config.py` (macOS):
@@ -501,7 +516,7 @@ import pandas
 allow({pandas.DataFrame: ['head', 'describe', 'info', 'shape']})
 
 # Allow pandas to write CSV to ~/data
-allow_write({'DataFrame.to_csv': PosWritePolicy(0, 'path_or_buf')})
+allow({pandas.DataFrame: [('to_csv', PosAllowPolicy(0, 'path_or_buf'))]})
 ```
 
 If the config file has errors, a warning is emitted and the defaults

--- a/nbs/00_core.ipynb
+++ b/nbs/00_core.ipynb
@@ -795,7 +795,7 @@
    "outputs": [],
    "source": [
     "#| export\n",
-    "default_ok_dests = None"
+    "default_ok_dests = ('.', '/tmp')"
    ]
   },
   {
@@ -809,6 +809,7 @@
     "class RunPython:\n",
     "    def __init__(self, g=None, sentinel=None, ok_dests=UNSET):\n",
     "        if ok_dests is UNSET: ok_dests = default_ok_dests\n",
+    "        elif ok_dests is not None: ok_dests = tuple(listify(ok_dests))\n",
     "        self.g = _find_frame_dict(sentinel) if g is None else g\n",
     "        self.ok_dests = ok_dests\n",
     "\n",

--- a/nbs/index.ipynb
+++ b/nbs/index.ipynb
@@ -197,7 +197,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "<tool>:2: UserWarning: a warning\n"
+      "<pyrun_3>:2: UserWarning: a warning\n",
+      "  warnings.warn('a warning')\n"
      ]
     },
     {
@@ -366,7 +367,7 @@
     {
      "data": {
       "text/plain": [
-       "6"
+       "np.int64(6)"
       ]
      },
      "execution_count": null,
@@ -398,7 +399,7 @@
     {
      "data": {
       "text/plain": [
-       "2.5"
+       "np.float64(2.5)"
       ]
      },
      "execution_count": null,
@@ -562,7 +563,7 @@
    "id": "b1a61544",
    "metadata": {},
    "source": [
-    "By default, `RunPython` blocks all filesystem writes. To enable controlled writing, pass `ok_dests` — a list of directory prefixes where writes are permitted. Writing to an allowed destination works normally, but writing anywhere else raises `PermissionError`:"
+    "By default, `RunPython()` allows writes to the current working directory (`.`) and `/tmp`, and blocks writes elsewhere. You can pass `ok_dests` to restrict writes to a different set of directory prefixes:"
    ]
   },
   {
@@ -616,7 +617,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Blocked: Dest '/etc/evil.txt' not allowed; permitted: ['/tmp']\n"
+      "Blocked: Dest '/etc/evil.txt' not allowed; permitted: ('/tmp',)\n"
      ]
     }
    ],
@@ -664,7 +665,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Blocked: Dest '/root/bad.txt' not allowed; permitted: ['/tmp']\n"
+      "Blocked: Dest '/root/bad.txt' not allowed; permitted: ('/tmp',)\n"
      ]
     }
    ],
@@ -741,7 +742,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Blocked: Dest '/root/bad.txt' not allowed; permitted: ['/tmp']\n"
+      "Blocked: Dest '/root/bad.txt' not allowed; permitted: ('/tmp',)\n"
      ]
     }
    ],
@@ -755,7 +756,7 @@
    "id": "1fa9c7d7",
    "metadata": {},
    "source": [
-    "Without `ok_dests`, the default `RunPython` instance blocks all write operations entirely — `Path.write_text` isn't even callable:"
+    "By default, `RunPython()` uses `default_ok_dests`, which allows writes in `.` and `/tmp` but blocks writes elsewhere."
    ]
   },
   {
@@ -763,10 +764,53 @@
    "execution_count": null,
    "id": "9c74ebb3",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Default blocked: Dest '/etc/nope.txt' not allowed; permitted: ('.', '/tmp')\n"
+     ]
+    }
+   ],
    "source": [
-    "try: await pyrun(\"Path('/tmp/test.txt').write_text('nope')\")\n",
-    "except AttributeError as e: print(f'No ok_dests: {e}')"
+    "await pyrun(\"Path('test_default_ok.txt').write_text('ok')\")\n",
+    "await pyrun(\"Path('/tmp/test_default_tmp.txt').write_text('tmp')\")\n",
+    "\n",
+    "try: await pyrun(\"Path('/etc/nope.txt').write_text('bad')\")\n",
+    "except PermissionError as e: print(f'Default blocked: {e}')\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "44ef751c",
+   "metadata": {},
+   "source": [
+    "If you want to disable write protection entirely, pass `ok_dests=None`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "644362ac",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "2"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "\n",
+    "pyrun_unrestricted = RunPython(ok_dests=None)\n",
+    "unrestricted_path = Path.home()/'safepyrun-unrestricted.txt'\n",
+    "await pyrun_unrestricted(f\"Path({str(unrestricted_path)!r}).write_text('ok')\")"
    ]
   },
   {
@@ -878,9 +922,9 @@
    "id": "f6cdfa51",
    "metadata": {},
    "source": [
-    "When `ok_dests` is set, safepyrun uses write policies to determine how to validate each callable's destination arguments. Three built-in policy classes cover common patterns: checking a positional or keyword argument (`PosWritePolicy`), checking the `Path` object itself (`PathWritePolicy`), and checking `open()` calls only when the mode is writable (`OpenWritePolicy`). You can also subclass `WritePolicy` to create custom checks.\n",
+    "When `ok_dests` is set, safepyrun uses write policies to determine how to validate each callable's destination arguments. Three built-in policy classes cover common patterns: checking a positional or keyword argument (`PosAllowPolicy`), checking the `Path` object itself (`PathWritePolicy`), and checking `open()` calls only when the mode is writable (`OpenWritePolicy`). You can also subclass `AllowPolicy` to create custom checks.\n",
     "\n",
-    "The simplest, `PosWritePolicy`, checks a specific positional or keyword argument against the allowed destinations. Here, position 1 (or keyword `dst`) is validated — writing to `/tmp` is allowed, but `/root` is blocked:"
+    "The simplest, `PosAllowPolicy`, checks a specific positional or keyword argument against the allowed destinations. Here, position 1 (or keyword `dst`) is validated — writing to `/tmp` is allowed, but `/root` is blocked:"
    ]
   },
   {
@@ -909,7 +953,7 @@
    "id": "718c8783",
    "metadata": {},
    "source": [
-    "You can create custom write policies by subclassing `WritePolicy` and implementing the `check` method. For example, here we show a policy that only allows writes to files with specific extensions — useful if you want the LLM to create `.csv` or `.json` files but not arbitrary scripts.\n",
+    "You can create custom write policies by subclassing `AllowPolicy` and implementing `__call__`. For example, here we show a policy that only allows writes to files with specific extensions — useful if you want the LLM to create `.csv` or `.json` files but not arbitrary scripts.\n",
     "\n",
     "The `__call__` signature receives `(obj, args, kwargs, ok_dests)` where `obj` is the object the method is called on (e.g. a `Path` instance), `args`/`kwargs` are the method's arguments, and `ok_dests` is the list of permitted directory prefixes. Calling `chk_dest` first handles the directory check, then the custom logic adds the extension constraint on top."
    ]
@@ -981,7 +1025,7 @@
    "id": "5b680813",
    "metadata": {},
    "source": [
-    "`safepyrun` loads an optional user config from `{xdg_config_home}/safepyrun/config.py` at import time, after all defaults are registered. This lets you permanently extend the sandbox allowlists without modifying the package. The config file is executed with all `safepyrun.core` globals already available, so no imports are needed. This includes `allow`, `allow_write`, `WritePolicy`, `PathWritePolicy`, `PosWritePolicy`, `OpenWritePolicy`, and all standard library modules already imported by the module.\n",
+    "`safepyrun` loads an optional user config from `{xdg_config_home}/safepyrun/config.py` at import time, after all defaults are registered. This lets you permanently extend the sandbox allowlists without modifying the package. The config file is executed with all `safepyrun.core` globals already available, so no imports are needed. This includes `allow`, `allow_write_types`, `AllowPolicy`, `PathWritePolicy`, `PosAllowPolicy`, `OpenWritePolicy`, and all standard library modules already imported by the module.\n",
     "\n",
     "Example `~/.config/safepyrun/config.py` (Linux) or `~/Library/Application Support/safepyrun/config.py` (macOS):\n",
     "\n",
@@ -992,7 +1036,7 @@
     "allow({pandas.DataFrame: ['head', 'describe', 'info', 'shape']})\n",
     "\n",
     "# Allow pandas to write CSV to ~/data\n",
-    "allow_write({'DataFrame.to_csv': PosWritePolicy(0, 'path_or_buf')})\n",
+    "allow({pandas.DataFrame: [('to_csv', PosAllowPolicy(0, 'path_or_buf'))]})\n",
     "```\n",
     "\n",
     "If the config file has errors, a warning is emitted and the defaults remain intact."

--- a/safepyrun/core.py
+++ b/safepyrun/core.py
@@ -296,12 +296,13 @@ async def _run_python(code:str, g=None, ok_dests=None):
     return res
 
 # %% ../nbs/00_core.ipynb #5d38a1d0
-default_ok_dests = None
+default_ok_dests = ('.', '/tmp')
 
 # %% ../nbs/00_core.ipynb #5447b52c
 class RunPython:
     def __init__(self, g=None, sentinel=None, ok_dests=UNSET):
         if ok_dests is UNSET: ok_dests = default_ok_dests
+        elif ok_dests is not None: ok_dests = tuple(listify(ok_dests))
         self.g = _find_frame_dict(sentinel) if g is None else g
         self.ok_dests = ok_dests
 


### PR DESCRIPTION
Fixed 2 issues:
1. Outdated policies in the readme that no longer exist.
2. Bug where `RunPython()` by default would block no writes at all.

This happened when `RunPython(ok_dests=None)` then would use the default which is none `default_ok_dests = None`. After discussing w/ Piotr and people in the call, the correct should be by default write to current dir and /tmp, so `default_ok_dests = ('.', '/tmp')`

Also created a tuple from the ok_dests to avoid modifying the list inplace which would be unsafe (although I think by default we do not allow inplace modification). It's a nice-to-have but maybe not required.