### PR TITLE
[codex] Restore safepyrun allow imports for package helpers

### DIFF
--- a/nbs/00_core.ipynb
+++ b/nbs/00_core.ipynb
@@ -33,6 +33,8 @@
     "from pyskills import *\n",
     "from pyskills import __pytools__\n",
     "\n",
+    "_all_ = ['allow', 'AllowPolicy', 'PosAllowPolicy', 'PathWritePolicy', 'OpenWritePolicy']\n",
+    "\n",
     "from inspect import currentframe,Parameter,signature\n",
     "from contextvars import ContextVar\n",
     "\n",
@@ -48,6 +50,17 @@
     "from IPython.display import display,HTML,Markdown,Image,Pretty,SVG\n",
     "from types import SimpleNamespace\n",
     "from re import Pattern"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a2e8f4c1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from safepyrun import allow as _public_allow\n",
+    "assert _public_allow is allow"
    ]
   },
   {

--- a/safepyrun/core.py
+++ b/safepyrun/core.py
@@ -3,7 +3,7 @@
 # %% auto #0
 __all__ = ['all_builtins', 'ALLOWED_DUNDERS', 'default_ok_dests', 'find_var', 'allow_write_types', 'sdir', 'SafeTransformer',
            'should_export', 'srcfn', 'RunPython', 'create_pyrun_magic', 'allow_matplotlib', 'load_ipython_extension',
-           'cli']
+           'cli', 'allow', 'AllowPolicy', 'PosAllowPolicy', 'PathWritePolicy', 'OpenWritePolicy']
 
 # %% ../nbs/00_core.ipynb #468aa264
 from fastcore.utils import *
@@ -12,6 +12,8 @@ from fastcore.xdg import xdg_config_home
 from fastcore.docments import MarkdownRenderer
 from pyskills import *
 from pyskills import __pytools__
+
+_all_ = ['allow', 'AllowPolicy', 'PosAllowPolicy', 'PathWritePolicy', 'OpenWritePolicy']
 
 from inspect import currentframe,Parameter,signature
 from contextvars import ContextVar


### PR DESCRIPTION
## Summary
- Expose `pyskills.allow` from `safepyrun`'s top-level public API again.
- Also expose the related pyskills policy classes that are already imported into `safepyrun.core`.
- Add a notebook regression cell covering `from safepyrun import allow`.

## Root cause
Released `solvecdp` and `fastcdp` wheels still call `from safepyrun import allow` in `cdp_yolo()`, but `safepyrun`'s generated `__all__` stopped exporting the imported pyskills API. That made `cdp_yolo()` fail even though `safepyrun.core` already had `allow` in its globals.

## Impact
Old and current downstream helpers can keep working after a `safepyrun` update, without requiring every downstream package to release in lockstep.

## Validation
- `uv run --no-project --with pyskills --with fastcore --with restrictedpython --with restrictedpython-async --with httpx --with 'matplotlib>=3.10.8' python -c ...`
- `uv run --no-project --with nbdev --with pyskills --with fastcore --with restrictedpython --with restrictedpython-async --with httpx --with 'matplotlib>=3.10.8' python -c "from nbdev.test import nbdev_test; nbdev_test(path='nbs/00_core.ipynb', do_print=True)"`
- `uv run --no-project --with solvecdp==0.0.5 python -c ... cdp_yolo()`
- `uv run --no-project --with fastcdp==0.0.5 python -c ... cdp_yolo()`