### PR TITLE
Misc fixes

### DIFF
--- a/nbs/02_safer.ipynb
+++ b/nbs/02_safer.ipynb
@@ -559,8 +559,8 @@
     "#| export\n",
     "def _safe_import(name, globals=None, locals=None, fromlist=(), level=0):\n",
     "    if name not in sys.modules: raise PermissionError(f\"{name} not preloaded\")\n",
-    "    if not fromlist: return __import__(name, globals=globals, locals=locals, level=level)\n",
-    "    return SimpleNamespace(**{n:rg['_getattr_'](mod, n) for n in fromlist})\n",
+    "    mod = __import__(name, globals=globals, locals=locals, fromlist=fromlist, level=level)\n",
+    "    return mod if not fromlist else SimpleNamespace(**{n: globals['_getattr_'](mod, n) for n in fromlist})\n",
     "\n",
     "_builtins = dict(builtins.__dict__) | dict(__import__ = _safe_import)"
    ]

--- a/safepyrun/safer.py
+++ b/safepyrun/safer.py
@@ -222,8 +222,8 @@ srcfn.i=0
 # %% ../nbs/02_safer.ipynb #b6724773
 def _safe_import(name, globals=None, locals=None, fromlist=(), level=0):
     if name not in sys.modules: raise PermissionError(f"{name} not preloaded")
-    if not fromlist: return __import__(name, globals=globals, locals=locals, level=level)
-    return SimpleNamespace(**{n:rg['_getattr_'](mod, n) for n in fromlist})
+    mod = __import__(name, globals=globals, locals=locals, fromlist=fromlist, level=level)
+    return mod if not fromlist else SimpleNamespace(**{n: globals['_getattr_'](mod, n) for n in fromlist})
 
 _builtins = dict(builtins.__dict__) | dict(__import__ = _safe_import)
 


### PR DESCRIPTION
Fixes an issue in  `_safe_import`
1. `rg` was undefined (it should be globals) 
2. the `mod` in `globals['_getattr_'](mod, n)` was not available either

Originally the PR changed the empty default dests to `default_ok_dests = ('.', '/tmp')` but considering the new `safepyrun.audit` which is designed to not get in the way too much, I think it's fine keeping audit more restricted by default with `default_ok_dests = ()`. 

