### PR TITLE
fixed generators issue

### DIFF
--- a/nbs/00_core.ipynb
+++ b/nbs/00_core.ipynb
@@ -445,7 +445,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f7162625",
+   "id": "7dad9339",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -465,7 +465,9 @@
     "    res = None\n",
     "    if tree.body and isinstance(tree.body[-1], ast.Expr):\n",
     "        last = tree.body.pop()\n",
-    "        if tree.body: await run(ast.unparse(ast.Module(tree.body, [])))\n",
+    "        if tree.body:\n",
+    "            await run(ast.unparse(ast.Module(tree.body, [])))\n",
+    "            rg.update(loc) # generators resolve inner vars from globals, so we need to make sure they are in `loc`\n",
     "        res = await run(ast.unparse(ast.Expression(last.value)), False)\n",
     "    else: await run(code)\n",
     "    g.update(loc)\n",
@@ -474,10 +476,47 @@
   },
   {
    "cell_type": "markdown",
-   "id": "38a798c9",
+   "id": "4cb9228b",
    "metadata": {},
    "source": [
     "`_run_python` is the core sandbox executor. It runs code under `fastaudit`, handles the last-expression-as-return-value pattern, and exports locals back to the caller's namespace unless they'd shadow an existing callable or module; `_`-suffixed names always export."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "43b57d10",
+   "metadata": {},
+   "source": [
+    "`__run_python` executes user code with separate globals (`rg`) and locals (`loc`) mappings. Earlier top-level assignments are written into `loc`. Most final expressions can still see those names because they are evaluated with the same locals mapping.\n",
+    "\n",
+    "Generator expressions are different: they run in their own nested scope. When the generator body later resolves a name assigned by an earlier statement, it looks in the globals mapping (`rg`), not the outer `eval` locals mapping (`loc`). So code like `x = 10; sum(i+x for i in [1,2])` failed with `NameError` because `x` was only in `loc`.\n",
+    "\n",
+    "After executing the non-final statements, `rg.update(loc)` copies those assigned names into the globals mapping before evaluating the final expression. This preserves the notebook-style behavior where names defined earlier in the cell are visible inside generators, comprehensions, lambdas, and other nested scopes used by the final expression."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6f31afbf",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "23"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "await __run_python(\n",
+    "    \"rnd_var_name_123 = 10\\n\"\n",
+    "    \"sum(x + rnd_var_name_123 for x in [1, 2])\",\n",
+    "    g={}\n",
+    ")"
    ]
   },
   {

--- a/safepyrun/core.py
+++ b/safepyrun/core.py
@@ -125,7 +125,7 @@ async def _run_python(code:str, g=None, ok_dests=None):
     with mk_audit(ok_dests, before_deny=before_deny, data=data, on_call=on_call)():
         return await __run_python(code=code, g=g, ok_dests=ok_dests)
 
-# %% ../nbs/00_core.ipynb #f7162625
+# %% ../nbs/00_core.ipynb #7dad9339
 _builtins = dict(builtins.__dict__)
 
 async def __run_python(code:str, g=None, ok_dests=None):
@@ -141,7 +141,9 @@ async def __run_python(code:str, g=None, ok_dests=None):
     res = None
     if tree.body and isinstance(tree.body[-1], ast.Expr):
         last = tree.body.pop()
-        if tree.body: await run(ast.unparse(ast.Module(tree.body, [])))
+        if tree.body:
+            await run(ast.unparse(ast.Module(tree.body, [])))
+            rg.update(loc) # generators resolve inner vars from globals, so we need to make sure they are in `loc`
         res = await run(ast.unparse(ast.Expression(last.value)), False)
     else: await run(code)
     g.update(loc)


### PR DESCRIPTION
If a generator expression relies on previous local variables and is the last expression it breaks:

<img width="1173" height="619" alt="image" src="https://github.com/user-attachments/assets/0263c4e5-9230-41bb-826a-13558a2be7be" />


The issue is that generators create their own nested function-like scope. To resolve vars they do so against the globals but the var it looks for is in `locals`.

This PR updates the `rg` values with the `globals` so generators resolve correctly. I added an explanation cell and a code cell testing it because it seems easy to forget / break.