### PR TITLE
Fix generator scoping: use shared globals dict for locals

### DIFF
--- a/nbs/00_core.ipynb
+++ b/nbs/00_core.ipynb
@@ -508,10 +508,11 @@
     "#| export\n",
     "_builtins = dict(builtins.__dict__)\n",
     "\n",
+    "_injected_names = ('__builtins__','__name__')\n",
     "async def __run_python(code:str, g=None, ok_dests=None):\n",
     "    _rp_globals.set(g)\n",
     "    rg = g | dict(__builtins__=_builtins, __name__='<pyrun>')\n",
-    "    loc = {}\n",
+    "    loc = rg\n",
     "    async def run(src, is_exec=True):\n",
     "        comp = compile(src, srcfn(src), 'exec' if is_exec else 'eval', flags=ast.PyCF_ALLOW_TOP_LEVEL_AWAIT)\n",
     "        r = eval(comp, rg, loc)\n",
@@ -521,12 +522,10 @@
     "    res = None\n",
     "    if tree.body and isinstance(tree.body[-1], ast.Expr):\n",
     "        last = tree.body.pop()\n",
-    "        if tree.body:\n",
-    "            await run(ast.unparse(ast.Module(tree.body, [])))\n",
-    "            rg.update(loc) # generators resolve inner vars from globals, so we need to make sure they are in `loc`\n",
+    "        if tree.body: await run(ast.unparse(ast.Module(tree.body, [])))\n",
     "        res = await run(ast.unparse(ast.Expression(last.value)), False)\n",
     "    else: await run(code)\n",
-    "    g.update(loc)\n",
+    "    g.update({k:v for k,v in loc.items() if k not in _injected_names})\n",
     "    return res"
    ]
   },
@@ -535,11 +534,9 @@
    "id": "b3932b1f",
    "metadata": {},
    "source": [
-    "`__run_python` executes user code with separate globals (`rg`) and locals (`loc`) mappings. Earlier top-level assignments are written into `loc`. Most final expressions can still see those names because they are evaluated with the same locals mapping.\n",
+    "`__run_python` executes user code with separate globals (`rg`) and locals (`loc`) mappings. However, generator expressions run in their own nested scope. When the generator body resolves a name assigned by an earlier statement, it looks in the globals mapping (`rg`), not the outer `eval` locals mapping (`loc`). So code like `x = 10; sum(i+x for i in [1,2])` failed with `NameError` because `x` was only in `loc`.\n",
     "\n",
-    "Generator expressions are different: they run in their own nested scope. When the generator body later resolves a name assigned by an earlier statement, it looks in the globals mapping (`rg`), not the outer `eval` locals mapping (`loc`). So code like `x = 10; sum(i+x for i in [1,2])` failed with `NameError` because `x` was only in `loc`.\n",
-    "\n",
-    "After executing the non-final statements, `rg.update(loc)` copies those assigned names into the globals mapping before evaluating the final expression. This preserves the notebook-style behavior where names defined earlier in the cell are visible inside generators, comprehensions, lambdas, and other nested scopes used by the final expression."
+    "The fix is to execute user code with `loc` and `rg` pointing at the same mapping. Then assignments made by earlier statements are immediately visible in the globals mapping that nested scopes use, so generators, comprehensions, lambdas, and nested functions can resolve those names anywhere in the cell, not only in the final expression. This is closer to normal module/notebook execution, where top-level names live in one shared namespace. The only extra cleanup is that `rg` also contains names injected by the runner, currently `__builtins__` and `__name__`, so `_injected_names` is filtered out when writing the user namespace back to `g`.\n"
    ]
   },
   {
@@ -563,6 +560,29 @@
     "await __run_python(\n",
     "    \"rnd_var_name_123 = 10\\n\"\n",
     "    \"sum(x + rnd_var_name_123 for x in [1, 2])\",\n",
+    "    g={}\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1f5730f0",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "rnd_var_name_123\n"
+     ]
+    }
+   ],
+   "source": [
+    "await __run_python(\n",
+    "    \"rnd_var_name_123 = 10\\n\"\n",
+    "    \"sum(x + rnd_var_name_123 for x in [1, 2])\\n\"\n",
+    "    \"print('rnd_var_name_123')\",\n",
     "    g={}\n",
     ")"
    ]

--- a/safepyrun/core.py
+++ b/safepyrun/core.py
@@ -166,10 +166,11 @@ srcfn.i=0
 # %% ../nbs/00_core.ipynb #7dad9339
 _builtins = dict(builtins.__dict__)
 
+_injected_names = ('__builtins__','__name__')
 async def __run_python(code:str, g=None, ok_dests=None):
     _rp_globals.set(g)
     rg = g | dict(__builtins__=_builtins, __name__='<pyrun>')
-    loc = {}
+    loc = rg
     async def run(src, is_exec=True):
         comp = compile(src, srcfn(src), 'exec' if is_exec else 'eval', flags=ast.PyCF_ALLOW_TOP_LEVEL_AWAIT)
         r = eval(comp, rg, loc)
@@ -179,12 +180,10 @@ async def __run_python(code:str, g=None, ok_dests=None):
     res = None
     if tree.body and isinstance(tree.body[-1], ast.Expr):
         last = tree.body.pop()
-        if tree.body:
-            await run(ast.unparse(ast.Module(tree.body, [])))
-            rg.update(loc) # generators resolve inner vars from globals, so we need to make sure they are in `loc`
+        if tree.body: await run(ast.unparse(ast.Module(tree.body, [])))
         res = await run(ast.unparse(ast.Expression(last.value)), False)
     else: await run(code)
-    g.update(loc)
+    g.update({k:v for k,v in loc.items() if k not in _injected_names})
     return res
 
 # %% ../nbs/00_core.ipynb #eb4dd8c6


### PR DESCRIPTION
## Problem

Generators (and other closures) resolve free variables from the enclosing scope's globals, not locals. When `loc` was a separate dict from `rg`, variables defined in earlier statements were invisible to
 generators defined later, causing `NameError` at iteration time.

I fixed once this scoping issue for generators in [this PR](https://github.com/AnswerDotAI/safepyrun/pull/45). However, the PR only addressed the issue when the generator statement is the last line because it copies `loc` to `rg` before running last statement.

## Solution

The issue still happens when the generator is not the last line. This PR fixes it by:
 - Set `loc = rg` so locals and globals share the same dict, eliminating the scoping gap
 - Remove the now-unnecessary `rg.update(loc)` workaround
 - Filter injected names (`__builtins__`, `__name__`) when propagating results back to the caller's globals

I have added a new example to make sure it does not break and update the note explanation to reflect the changes.

## Discussion required

> [!WARNING]
>  What is needed to move this PR out of draft.


After reviewing the changes w/ SolveIT I realized these changes mean that any changes done to `g` during `pyrun` code execution will be overwriten with stale `rg`. 

But I don't know if that is a bug or a feature.  Are `RunPython(g=...)`  side effects on the original `g` intended or not?

`rg = g | ...` only copies the namespace dict, not the underlying objects/functions, so sandboxed code can still affect original state through shared references (for example, mutating a shared list or calling a function whose `__globals__` is `g`). 

Before this change, the final `g.update(loc)` mostly exported newly bound names; with `loc = rg`, it now writes back the whole copied namespace, which can overwrite those side effects with stale snapshot values. 
