### PR TITLE
Make `AllowPolicy` check additive

### DIFF
--- a/nbs/00_core.ipynb
+++ b/nbs/00_core.ipynb
@@ -339,10 +339,16 @@
     "    if isinstance(v, tuple): v = (v,)\n",
     "    if name in v: return True\n",
     "    aa = list(a[1:] if obj is not None and a and a[0] is obj else a)\n",
+    "    denied = []\n",
     "    for x in v:\n",
     "        if isinstance(x, tuple) and (x[0] is ... or x[0] == name):\n",
-    "            x[1](obj, aa, kw, data)\n",
-    "            return True\n",
+    "            try:\n",
+    "                x[1](obj, aa, kw, data)\n",
+    "                return True\n",
+    "            except PermissionError as e:\n",
+    "                denied.append(str(e))\n",
+    "                continue\n",
+    "    if denied: raise PermissionError(\"; \".join(sorted(denied)))\n",
     "    return None if ... in v else False"
    ]
   },
@@ -1238,7 +1244,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/var/folders/51/b2_szf2945n072c0vj2cyty40000gn/T/ipymini_49065/3833129470.py:1: UserWarning: a warning\n",
+      "/var/folders/zl/js35kg3914qc7d8lsdtqsyf00000gn/T/ipymini_7028/3833129470.py:1: UserWarning: a warning\n",
       "  def f(): warnings.warn('a warning')\n"
      ]
     },
@@ -2178,13 +2184,80 @@
    "outputs": [],
    "source": [
     "class _OpT:\n",
+    "    def __init__(self,name): store_attr()\n",
     "    def __call__(self): return run('echo hi')\n",
     "\n",
-    "op_a,op_b = _OpT(),_OpT()\n",
+    "op_a,op_b,op_c = _OpT('a'),_OpT('b'),_OpT('c')\n",
     "with expect_fail(PermissionError): await python(\"op_a()\")\n",
     "allow(op_a)\n",
     "test_eq(await python(\"op_a()\"), \"hi\")\n",
     "with expect_fail(PermissionError): await python(\"op_b()\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8c0234ea",
+   "metadata": {},
+   "source": [
+    "Instead of allowing individual instances of `OpFunc` where the list can grow, allow policies can be used to allow at a higher level (e.g. checking `obj.base_url` of `OpenAPIClient`). Policies are additive and `AllowPolicy` will raise when none of the policies allow:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "97347c94",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "__pytools__.pop(op_a,None);"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bc33992b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class AllowOpTA(AllowPolicy):\n",
+    "    def __call__(self, obj, args, kwargs, data):\n",
+    "        if 'a' not in obj.name : raise PermissionError(f'Only \"a\" is allowed not: {obj.name}')\n",
+    "allow({_OpT:[('__call__', AllowOpTA())]})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7742f866",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "test_eq(await python(\"op_a()\"), \"hi\")\n",
+    "with expect_fail(PermissionError): await python(\"op_b()\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "07c544bb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class AllowOpTB(AllowPolicy):\n",
+    "    def __call__(self, obj, args, kwargs, data):\n",
+    "        if 'b' not in obj.name : raise PermissionError(f'Only \"b\" is allowed not: {obj.name}')\n",
+    "allow({_OpT:[('__call__', AllowOpTB())]})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6ab00f6e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "test_eq(await python(\"op_b()\"), \"hi\")\n",
+    "with expect_fail(PermissionError, 'Only \"a\" is allowed not: c; Only \"b\" is allowed not: c'): await python(\"op_c()\")"
    ]
   },
   {
@@ -2353,7 +2426,18 @@
    "execution_count": null,
    "id": "f3dde13b",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<Response [200 OK]>"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "set_data(ok_urls={'http://example.org'})\n",
     "await RunPython()('httpx.get(\"http://example.org\")')"
@@ -2459,7 +2543,18 @@
    "execution_count": null,
    "id": "9a27f49a",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'lower'}"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "with expect_fail(PermissionError, 'policy changed'): await python(\"__pytools__[str].add('lower')\")\n",
     "__pytools__.pop(str, None)"

--- a/safepyrun/core.py
+++ b/safepyrun/core.py
@@ -93,10 +93,16 @@ def _ctx_check(v, name, obj, a, kw, data):
     if isinstance(v, tuple): v = (v,)
     if name in v: return True
     aa = list(a[1:] if obj is not None and a and a[0] is obj else a)
+    denied = []
     for x in v:
         if isinstance(x, tuple) and (x[0] is ... or x[0] == name):
-            x[1](obj, aa, kw, data)
-            return True
+            try:
+                x[1](obj, aa, kw, data)
+                return True
+            except PermissionError as e:
+                denied.append(str(e))
+                continue
+    if denied: raise PermissionError("; ".join(sorted(denied)))
     return None if ... in v else False
 
 # %% ../nbs/00_core.ipynb #396f7992


### PR DESCRIPTION
`_ctx_check` iterated `__pytools__` entries in a set and returned `True` on the first policy that didn't raise. Since set iteration order is hash-based (non-deterministic), a `PermissionError` from one policy would block subsequent policies from being tried — so multiple `AllowPolicy` registrations on the same type/method were not truly additive.

Wrap each policy call in `try/except PermissionError`, collect denial messages, and continue to the next matching policy. If all deny, raise a single `PermissionError` combining all messages. This makes policies work as an OR: a call is allowed if *any* matching policy approves it.


Added tests to the notebook, and also tested here in this [dialog](https://share.solveit.pub/d/cbf766e2aafeab376eca7363f43955d8) - which first adds a policy for `GhApi` and then one for `OpenAI` fastspec client. 