### PR TITLE
Fix haskey check in half built objs

### DIFF
--- a/nbs/00_core.ipynb
+++ b/nbs/00_core.ipynb
@@ -416,10 +416,9 @@
     "    if mod and '.' in qn:\n",
     "        cls = getattr(mod, qn.rsplit('.', 1)[0], None)\n",
     "        obj = c.args[0] if cls and c.args and isinstance(c.args[0], cls) else None\n",
-    "        try: haskey = obj is not None and obj in pytools\n",
-    "        except TypeError: haskey = False\n",
-    "        if haskey:\n",
-    "            if (res := _ctx_check(pytools[obj], nm, obj, c.args, c.kwargs, data)): return True\n",
+    "        obj_pytools = next((v for k,v in pytools.items() if k is obj), None) if obj is not None else None\n",
+    "        if obj_pytools is not None:\n",
+    "            if (res := _ctx_check(obj_pytools, nm, obj, c.args, c.kwargs, data)): return True\n",
     "            if res is None: soft = True\n",
     "        typs = L(type(obj).__mro__ if obj is not None else ()) + L([cls]) + L(getattr(cls, '__mro__', ()))\n",
     "        for o in typs.unique():\n",
@@ -1254,7 +1253,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/var/folders/zl/js35kg3914qc7d8lsdtqsyf00000gn/T/ipymini_7028/3833129470.py:1: UserWarning: a warning\n",
+      "/var/folders/zl/js35kg3914qc7d8lsdtqsyf00000gn/T/ipymini_25340/3833129470.py:1: UserWarning: a warning\n",
       "  def f(): warnings.warn('a warning')\n"
      ]
     },

--- a/safepyrun/core.py
+++ b/safepyrun/core.py
@@ -126,10 +126,9 @@ def _call_allowed(c, data):
     if mod and '.' in qn:
         cls = getattr(mod, qn.rsplit('.', 1)[0], None)
         obj = c.args[0] if cls and c.args and isinstance(c.args[0], cls) else None
-        try: haskey = obj is not None and obj in pytools
-        except TypeError: haskey = False
-        if haskey:
-            if (res := _ctx_check(pytools[obj], nm, obj, c.args, c.kwargs, data)): return True
+        obj_pytools = next((v for k,v in pytools.items() if k is obj), None) if obj is not None else None
+        if obj_pytools is not None:
+            if (res := _ctx_check(obj_pytools, nm, obj, c.args, c.kwargs, data)): return True
             if res is None: soft = True
         typs = L(type(obj).__mro__ if obj is not None else ()) + L([cls]) + L(getattr(cls, '__mro__', ()))
         for o in typs.unique():


### PR DESCRIPTION
When `_call_allowed` checked exact-object entries with `obj in pytools`, dict membership could invoke user/library `__hash__` or `__eq__`. This broke on partially constructed objects, e.g. pandas `DatetimeTZDtype`, where `__hash__` depends on attributes that are assigned later in `__init__`.

<img width="824" height="416" alt="image" src="https://github.com/user-attachments/assets/35389260-73f8-4e68-ac3b-03a325ac6692" />

This PR changes the exact-object lookup to use identity comparison, preserving object-specific allow rules without running object code during permission checking.

Tested with a regression case where a half-built object triggers an audit denial before its hash-dependent attribute is initialized; it now raises the expected `PermissionError` instead of an unrelated `AttributeError`:

```py
from safepyrun.core import *

class HalfBuilt:
    def __init__(self):
        open('/not-allowed-by-safepyrun.txt', 'w')
        self._unit = "ns"
    @property
    def unit(self): return self._unit
    def __str__(self): return f"dtype[{self.unit}]"
    def __hash__(self): return hash(str(self))

python_obj_half = RunPython(g={'HalfBuilt': HalfBuilt})
await python_obj_half("hb = HalfBuilt()")
```

