### PR TITLE
Don't let a soft `...` allow grant filesystem side-effects

### DIFF
--- a/nbs/00_core.ipynb
+++ b/nbs/00_core.ipynb
@@ -442,7 +442,9 @@
     "    for c in info.calls:\n",
     "        if (res := _call_allowed(c, info.data)): return True\n",
     "        if res is None: soft = True\n",
-    "    return soft"
+    "    # soft `...` trusts a module's monitored *calls*, not its side effects: only native-call\n",
+    "    # events may be soft-allowed, so a compute allow can't bypass `open`/`ok_dests` confinement\n",
+    "    return soft and getattr(info, 'event', None) == 'fastaudit.call'"
    ]
   },
   {
@@ -454,7 +456,7 @@
     "\n",
     "`_call_allowed` checks one logical `CallInfo` against the pytool registry. It returns `True` when the call is allowed at module level, for the specific bound instance, or at class/MRO level, including constrained validator entries. It exists to centralize pytool lookup for both async tracked calls and stack-frame fallback calls.\n",
     "\n",
-    "`_ctx_allowed` checks every logical call in a `DenyInfo`. It returns `True` if any tracked or frame-derived call is registered as allowed. It exists so `before_deny` no longer duplicates stack walking or call matching logic."
+    "`_ctx_allowed` checks every logical call in a `DenyInfo`. It returns `True` if any call is allowed by a *hard* match — an explicit name or a validator that passed. A soft allow-all (`...`) only authorizes native-call monitor events (`fastaudit.call`), never side-effect events like `open`: this stops a broad compute allow (e.g. `pandas.*`) from letting code write outside `ok_dests`. It exists so `before_deny` no longer duplicates stack walking or call matching logic."
    ]
   },
   {
@@ -633,6 +635,21 @@
     "    data=dict(pytools={'matplotlib.*': ..., 'danger.*': {('save', _deny)}}))\n",
     "\n",
     "with expect_fail(): _ctx_allowed(info)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "330f6aa7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# A soft `...` allow trusts a module's monitored calls, but must not authorize its side effects:\n",
+    "# a broad compute allow (e.g. `pandas.*`) can't smuggle a write past `ok_dests` via `open`.\n",
+    "_c = CallInfo(module='vendor.mod', qualname='writer.dump', name='vendor.mod.writer.dump')\n",
+    "def _mk(ev): return types.SimpleNamespace(calls=[_c], data=dict(pytools={'vendor.*': {...}}), event=ev)\n",
+    "test_eq(_ctx_allowed(_mk('fastaudit.call')), True)   # native call: monitor bypass ok\n",
+    "test_eq(_ctx_allowed(_mk('open')), False)            # filesystem write: never soft-allowed"
    ]
   },
   {

--- a/safepyrun/core.py
+++ b/safepyrun/core.py
@@ -144,7 +144,9 @@ def _ctx_allowed(info):
     for c in info.calls:
         if (res := _call_allowed(c, info.data)): return True
         if res is None: soft = True
-    return soft
+    # soft `...` trusts a module's monitored *calls*, not its side effects: only native-call
+    # events may be soft-allowed, so a compute allow can't bypass `open`/`ok_dests` confinement
+    return soft and getattr(info, 'event', None) == 'fastaudit.call'
 
 # %% ../nbs/00_core.ipynb #53fe97bf
 class RawDenyInfo:


### PR DESCRIPTION
## Problem

The sandbox confines writes to `ok_dests`, and `allow(...)` grants callables exceptions. The `...` sentinel — `allow({'pandas.*': ...})`, `allow({'matplotlib.*': ...})` — is a **compute** allow: it lets a library's native calls bypass the call monitor. But `_ctx_allowed` returned `True` for *any* denied event as long as some frame in the stack matched a soft `...` entry.

pandas writes an xlsx by opening the destination itself (`pandas.io.common.get_handle` → stdlib `open`) with the whole stack being `pandas.*` frames. So the write `open`'s `ok_dests` denial was overridden by the `pandas.*` soft-allow, and a file could be written **anywhere**:

```python
allow({'pandas.*': ...})
pyrun = RunPython(ok_dests=[tmp])
await pyrun("pd.DataFrame({'a':[1]}).to_excel('~/.cache/anywhere.xlsx')")  # was NOT blocked
```

A compute allow shouldn't grant a filesystem escape. (Both `allow_matplotlib`/`allow_pandas` already pair `...` with explicit per-method write policies — confirming `...` was only ever meant for compute.)

## Fix

`_ctx_allowed` honours a soft `...` allow **only for native-call monitor events** (`fastaudit.call`), never for side-effect events like `open`:

```python
return soft and getattr(info, 'event', None) == 'fastaudit.call'
```

Hard allows (an explicit method name, or a validator/policy that passed) are unchanged and still return `True` immediately — so `allow_pandas()`'s `PosAllowPolicy` confinement, and any explicit tool allow, keep working.

Verified: with `allow({'pandas.*': ...})`, `to_excel`/`to_csv` outside `ok_dests` are now denied (no leaked file) while pandas compute still works and writes inside `ok_dests` succeed.

Pairs with fastaudit AnswerDotAI/fastaudit#23 (which lets openpyxl work without `safe_native` and keeps `NamedTemporaryFile` writes confined once this leak is closed).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
